### PR TITLE
Fix classifier_workflow yaml import error

### DIFF
--- a/dify_data_assistant/workflows/classifier_workflow.yaml
+++ b/dify_data_assistant/workflows/classifier_workflow.yaml
@@ -53,7 +53,7 @@ app:
                 user: "{{start.db_user}}"
                 password: "{{start.db_password}}"
                 database: "{{start.db_name}}"
-              refine_by_llm: {{start.refine_by_llm}}
+              refine_by_llm: "{{start.refine_by_llm}}"
           output:
             parse_type: json
         position:

--- a/dify_data_assistant/workflows/classifier_workflow_alt.yaml
+++ b/dify_data_assistant/workflows/classifier_workflow_alt.yaml
@@ -54,7 +54,7 @@ app:
                 user: "{{start.db_user}}"
                 password: "{{start.db_password}}"
                 database: "{{start.db_name}}"
-              refine_by_llm: {{start.refine_by_llm}}
+              refine_by_llm: "{{start.refine_by_llm}}"
           timeout: 120
           output:
             parse_type: json


### PR DESCRIPTION
Quote `refine_by_llm` placeholder in Dify workflow YAMLs to resolve "found unhashable key" parsing error during import.

The YAML parser incorrectly interpreted `{{start.refine_by_llm}}` as an unhashable mapping key. Quoting it as `\"{{start.refine_by_llm}}\"` resolves this parsing issue, allowing the workflow to be imported successfully while preserving the intended boolean value for the backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0285c4a-50e6-495b-8b7f-122dedef14af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0285c4a-50e6-495b-8b7f-122dedef14af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

